### PR TITLE
fix(cli): catch UnicodeDecodeError in REPL input loop

### DIFF
--- a/packages/cli/deepseek_harness_cli/__main__.py
+++ b/packages/cli/deepseek_harness_cli/__main__.py
@@ -173,6 +173,9 @@ def _chat(model: str, reasoning: bool, max_tokens: int) -> int:
         except (EOFError, KeyboardInterrupt):
             console.print("\n[dim]bye.[/]")
             return 0
+        except UnicodeDecodeError:
+            console.print("[dim](ignored non-UTF-8 input; set terminal to UTF-8)[/]")
+            continue
         if not user:
             continue
         if user in ("/quit", "/exit"):


### PR DESCRIPTION
In WSL and some non-UTF-8 terminals, console.input() raises UnicodeDecodeError when stdin receives non-UTF-8 bytes (e.g. from IME composition or GBK-encoded input). This crashes the REPL with a traceback instead of recovering gracefully.

Catch UnicodeDecodeError alongside EOFError/KeyboardInterrupt, print a hint, and continue the loop.